### PR TITLE
Fixes broken image when the page does not have one

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -18,7 +18,9 @@
                             <header class="major">
                                 <h1>{{ .Title}}</h1>
                             </header>
-                            <span class="image main"><img src="{{ .Site.Params.baseURL }}/img/blogs/{{ .Params.image }}" alt="" /></span>
+                            {{ if .Params.image }}
+                                <span class="image main"><img src="{{ .Site.Params.baseURL }}/img/blogs/{{ .Params.image }}" alt="" /></span>
+                            {{ end }}
                             {{ .Content }}
                         </div>
                     </section>


### PR DESCRIPTION
Currently this is output when a page does not have an image:

```
<span class="image main"><img src="the_base_url/img/blogs/" alt="" /></span>
```

And so a broken image icon is shown on some browsers. This PR hides the html above if the page does not have an image specified.