### PR TITLE
Remove hard-coding of 'blogs' directory

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -32,7 +32,7 @@
                     {{ range .Pages }}
                     <section>
                         <a href="{{ .Slug }}" class="image">
-							<img src="{{ .Site.Params.baseURL }}/img/blogs/{{ .Params.image }}" alt="" data-position="center center" />
+							<img src="{{ .Site.Params.baseURL }}/img/{{ .Section }}/{{ .Params.image }}" alt="" data-position="center center" />
 						</a>
                         <div class="content">
                             <div class="inner">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -19,7 +19,7 @@
                                 <h1>{{ .Title}}</h1>
                             </header>
                             {{ if .Params.image }}
-                                <span class="image main"><img src="{{ .Site.Params.baseURL }}/img/blogs/{{ .Params.image }}" alt="" /></span>
+                                <span class="image main"><img src="{{ .Site.Params.baseURL }}/img/{{ .Section }}/{{ .Params.image }}" alt="" /></span>
                             {{ end }}
                             {{ .Content }}
                         </div>


### PR DESCRIPTION
This replaces the string 'blogs' with the variable for section, which will equal

Useful to for instance changed 'blogs' to 'news' in my content folder.  Hugo could do URL rewriting to the same effect, i think, but this way keeps the site editor experience (where to find markdown files) consistent with the site visitor experience.

Fixes #11