### PR TITLE
Only show Disqus comments if set in config.toml

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -25,7 +25,9 @@
                         </div>
                     </section>
             {{ "<!-- Disqus Inject -->" | safeHTML }}
-                {{ partial "disqus.html" . }}
+                {{ if .Site.DisqusShortname }}
+                  {{ partial "disqus.html" . }}
+                {{ end }}
             </div>
             
         {{ "<!-- Footer -->" | safeHTML}}


### PR DESCRIPTION
Currently, if you don't set disqusShortname in config.toml, you still get 'Comments provided by Disqus' at the bottom of pages.

I think this condition removes this (seems to work on my test site)—but it's my first time ever editing this kind of templating language!