### PR TITLE
Linking to .URL rather than .Slug

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -14,7 +14,7 @@
 			<div id="main">
 				<div class="inner">
 					<h1>{{ .Site.Params.Error404.heading }}</h1>
-					<p>{{ .Site.Params.Error404.text }}</p>
+					<p>{{ .Site.Params.Error404.text | markdownify }}</p>
 				</div>
 			</div>
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -31,7 +31,7 @@
                 <section id="two" class="spotlights">
                     {{ range .Pages }}
                     <section>
-                        <a href="{{ .Slug }}" class="image">
+                        <a href="{{ .URL }}" class="image">
 							<img src="{{ .Site.Params.baseURL }}/img/{{ .Section }}/{{ .Params.image }}" alt="" data-position="center center" />
 						</a>
                         <div class="content">
@@ -41,7 +41,7 @@
                                 </header>
                                 <p>{{ .Description }}</p>
                                 <ul class="actions">
-                                    <li><a href="{{ .Slug }}" class="button">Learn more</a></li>
+                                    <li><a href="{{ .URL }}" class="button">Learn more</a></li>
                                 </ul>
                             </div>
                         </div>


### PR DESCRIPTION
Sorry about this coming through twice - still learning hugo and git!

With the code as is, pages listing blog posts doesn't link to anything unless you specify a slug...and even that is different between running hugo locally and on netlify.

However, I've now checked, and this fix seems to work on my site, locally and on netlify.