### PR TITLE
Updated for Hugo 0.55

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -41,7 +41,7 @@
                                 </header>
                                 <p>{{ .Description }}</p>
                                 <ul class="actions">
-                                    <li><a href="{{ .URL }}" class="button">Learn more</a></li>
+                                    <li><a href="{{ .Permalink }}" class="button">Learn more</a></li>
                                 </ul>
                             </div>
                         </div>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -31,7 +31,7 @@
                 <section id="two" class="spotlights">
                     {{ range .Pages }}
                     <section>
-                        <a href="{{ .URL }}" class="image">
+                        <a href="{{ .Permalink }}" class="image">
 							<img src="{{ .Site.Params.baseURL }}/img/{{ .Section }}/{{ .Params.image }}" alt="" data-position="center center" />
 						</a>
                         <div class="content">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,7 +4,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 	{{ with .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
 	{{ with .Site.Params.name }}<meta name="author" content="{{ . }}">{{ end }}
-	{{ .Hugo.Generator }}
+	{{ hugo.Generator }}
 	<title>{{ .Title }}{{ if not .IsHome }} &middot; {{ .Site.Title }}{{ end }}</title>
 	{{ "<!-- Stylesheets -->" | safeHTML }}
 	<!--[if lte IE 8]><script src="js/ie/html5shiv.js"></script><![endif]-->

--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "A portfolio/blog website built for companies or personal freelanc
 homepage = "//github.com/MarcusVirg/forty"
 tags = ["portfolio", "company", "contact form", "google analytics", "blog"]
 features = ["blog"]
-min_version = "0.29"
+min_version = "0.55"
 
 [author]
   name = "Marcus Virginia"


### PR DESCRIPTION
Hugo 0.55 breaks some code in this theme. These changes fix most of those, though there are still warnings generated because `.url` is called in some places (though I don't think that's a problem because they are references to parameters in `config.toml`.