### PR TITLE
Use the correct property to generate the image src url

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -19,7 +19,7 @@
                                 <h1>{{ .Title}}</h1>
                             </header>
                             {{ if .Params.image }}
-                                <span class="image main"><img src="{{ .Site.Params.baseURL }}/img/{{ .Section }}/{{ .Params.image }}" alt="" /></span>
+                                <span class="image main"><img src="{{ .Site.BaseURL }}/img/{{ .Section }}/{{ .Params.image }}" alt="" /></span>
                             {{ end }}
                             {{ .Content }}
                         </div>


### PR DESCRIPTION
I found a bug where the picture set in the `.Site.Params.Image` doesn't get
a correct URL.
Hopefully this was the problem, and I fixed it.

Thank you.