### PR TITLE
fix: replace deprecated DisqusShortname reference

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -25,7 +25,7 @@
                         </div>
                     </section>
             {{ "<!-- Disqus Inject -->" | safeHTML }}
-                {{ if .Site.DisqusShortname }}
+                {{ if .Site.Config.Services.Disqus.Shortname }}
                   {{ partial "disqus.html" . }}
                 {{ end }}
             </div>

--- a/layouts/partials/disqus.html
+++ b/layouts/partials/disqus.html
@@ -9,7 +9,7 @@
                 return;
 
           var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-          var disqus_shortname = '{{ .Site.DisqusShortname }}';
+          var disqus_shortname = '{{ .Site.Config.Services.Disqus.Shortname }}';
           dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
           (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();


### PR DESCRIPTION
Replaced .Site.DisqusShortname with .Site.Config.Services.Disqus.Shortname as recommended for Hugo 0.120.0 and above. See: https://github.com/gohugoio/hugo/releases/tag/v0.120.0
